### PR TITLE
Improve security of the jelly view by enabling the escape by default.

### DIFF
--- a/src/main/resources/com/google/jenkins/plugins/credentials/oauth/OAuth2ScopeSpecification/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/credentials/oauth/OAuth2ScopeSpecification/config.jelly
@@ -13,8 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
-         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
   <j:choose>
     <j:set var="scopeOptions" value="${descriptor.scopeItems}" />
     <j:when test="${!empty(scopeOptions)}">


### PR DESCRIPTION
Should not be a problem since the data is coming from code directly but always better to enforce best practices.