### PR TITLE
Fix "OAuth Credentials" type

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/credentials/oauth/OAuth2Credentials.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/oauth/OAuth2Credentials.java
@@ -37,22 +37,4 @@ public interface OAuth2Credentials<T extends OAuth2ScopeRequirement>
    * @return the scoped access token
    */
   Secret getAccessToken(T requirement);
-
-  /**
-   * Our descriptor.
-   */
-  @Extension
-  public static class DescriptorImpl extends CredentialsDescriptor {
-
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @NonNull
-    public String getDisplayName() {
-      return "OAuth Credentials";
-    }
-
-  }
 }

--- a/src/test/java/com/google/jenkins/plugins/credentials/oauth/OAuth2ScopeSpecificationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/credentials/oauth/OAuth2ScopeSpecificationTest.java
@@ -23,10 +23,15 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
+import com.cloudbees.plugins.credentials.CredentialsDescriptor;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.util.Secret;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.WithoutJenkins;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -179,7 +184,7 @@ public class OAuth2ScopeSpecificationTest {
 
   /**
    */
-  @Extension
+  @TestExtension
   public static class CustomProvider extends DomainRequirementProvider {
     @Override
     protected <T extends DomainRequirement> List<T> provide(Class<T> type) {
@@ -202,8 +207,7 @@ public class OAuth2ScopeSpecificationTest {
     assertThat(discovered, not(hasItems(BAD_SCOPE)));
   }
 
-  @Mock
-  private OAuth2Credentials mockCredentials;
+  private OAuth2Credentials mockCredentials = new MockOAuthCredentials();
 
   /**
    * Verify that credentials that appear outside of a domain with
@@ -380,6 +384,34 @@ public class OAuth2ScopeSpecificationTest {
             Jenkins.get(), ACL.SYSTEM, new TestBadRequirement());
 
     assertThat(matchingCredentials, not(hasItems(mockCredentials)));
+  }
+
+  public static final class MockOAuthCredentials implements OAuth2Credentials {
+
+    @Override
+    public Secret getAccessToken(OAuth2ScopeRequirement requirement) {
+      return null;
+    }
+
+    @Override
+    public CredentialsScope getScope() {
+      return null;
+    }
+
+    @NonNull
+    @Override
+    public CredentialsDescriptor getDescriptor() {
+      return (DescriptorImpl) Jenkins.get().getDescriptorOrDie(getClass());
+    }
+
+    @TestExtension
+    public static class DescriptorImpl extends CredentialsDescriptor {
+      @Override
+      @NonNull
+      public String getDisplayName() {
+        return "OAuth Mock Credentials";
+      }
+    }
   }
 
 


### PR DESCRIPTION
Having an `Extension` in an interface is telling Jenkins the class is defining a credential type, but it's not as effective implementations are written in child classes in other plugins.

This is fixing https://github.com/jenkinsci/google-oauth-plugin/issues/147

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
