### PR TITLE
Migrate from javax.annotation to findbugs annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.28</version>
+    <version>6.2138.v03274d462c13</version>
     <relativePath />
   </parent>
 
@@ -95,12 +95,6 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest</artifactId>
-        <version>2.2</version>
-        <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/com/google/jenkins/plugins/credentials/domains/DomainRequirementProvider.java
+++ b/src/main/java/com/google/jenkins/plugins/credentials/domains/DomainRequirementProvider.java
@@ -20,11 +20,10 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.annotation.Nullable;
-
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;


### PR DESCRIPTION
Replace `javax.annotation.*` imports with `edu.umd.cs.findbugs.annotations.*` equivalents.

Jenkins core 2.529+ removed jsr305 from classpath (guava 33.5 no longer includes it as transitive dependency). As a result, plugins using `javax.annotation.*` will encounter compile-time errors when building against the updated core. These plugins must migrate to using spotbugs annotations, following the approach taken by Jenkins core.

This ensure the plugin will be compatible with jenkins-core requiring jdk21 


### Testing done
```bash
mvn clean verify 
```
javac with target 21 inherit from `jenkins.version`
```bash
mvn clean verify -Djenkins.version=2.552-cb-39926 \
    -Dhpi-plugin.version=3.1808.v891993858dd2 \
    -Djenkins-test-harness.version=2553.vd280528b_dde3 
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
