### PR TITLE
Rely on junit and hamcrest dependency from Jenkins test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,18 +92,8 @@
 
     <!-- Test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Rely on junit and hamcrest dependency from Jenkins test harness

Only 3 of the top 250 most popular, actively maintained plugins declare a dependency on junit. All the rest rely on the dependency that is provided by the Jenkins test harness.

The hamcrest dependency is also provided by the Jenkins test harness.

### Testing done

* Confirmed that tests pass with the proposed change

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
